### PR TITLE
PP-15836 add Dependabot exclude cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,9 @@ updates:
         versions:
           - ">= 7"
       - dependency-name: "io.netty:netty-bom"
+    cooldown:
+      exclude:
+        - "uk.gov.service.payments:*"
     open-pull-requests-limit: 10
     labels:
       - dependencies


### PR DESCRIPTION
## WHAT YOU DID

Exclude pay-java-commons from the cooldown period of dependabot updates.
